### PR TITLE
Add some warning : innodb_log_file_size update 

### DIFF
--- a/data/database/mysql-global.conf
+++ b/data/database/mysql-global.conf
@@ -95,7 +95,7 @@ innodb_log_buffer_size=1M
 innodb_buffer_pool_size=80M
 
 # size of average write burst, keep Innob_log_waits small, keep Innodb_buffer_pool_wait_free small (see show global status like "inno%", show global variables)
-#Warnibg : update innodb_log_file_size on one existing instance of mysql server will make mysql fails to restart. A good explanation on the way to proceed is readable here : https://web.archive.org/web/20151026013447/http://dba.stackexchange.com/questions/18495/mysql-wont-start-after-increasing-innodb-buffer-pool-size-and-innodb-log-file-si/18553 
+# Warning : update innodb_log_file_size on one existing instance of mysql server will make mysql fails to restart. A good explanation on the way to proceed is readable here : https://web.archive.org/web/20151026013447/http://dba.stackexchange.com/questions/18495/mysql-wont-start-after-increasing-innodb-buffer-pool-size-and-innodb-log-file-si/18553 
 innodb_log_file_size=64M
 innodb_flush_log_at_trx_commit=2
 

--- a/data/database/mysql-global.conf
+++ b/data/database/mysql-global.conf
@@ -95,6 +95,7 @@ innodb_log_buffer_size=1M
 innodb_buffer_pool_size=80M
 
 # size of average write burst, keep Innob_log_waits small, keep Innodb_buffer_pool_wait_free small (see show global status like "inno%", show global variables)
+#Warnibg : update innodb_log_file_size on one existing instance of mysql server will make mysql fails to restart. A good explanation on the way to proceed is readable here : https://web.archive.org/web/20151026013447/http://dba.stackexchange.com/questions/18495/mysql-wont-start-after-increasing-innodb-buffer-pool-size-and-innodb-log-file-si/18553 
 innodb_log_file_size=64M
 innodb_flush_log_at_trx_commit=2
 


### PR DESCRIPTION
Hello,

I had some warning to innodb_log_file_size modification that should make mysql server fail to restart if mysql is yet used and configured before running Digikam.

Thanks,

Eric