### PR TITLE
allow D&D for clock photo in batch queue manager

### DIFF
--- a/utilities/queuemanager/CMakeLists.txt
+++ b/utilities/queuemanager/CMakeLists.txt
@@ -45,6 +45,7 @@ set(libqueuemanager_SRCS
     tools/metadata/timeadjustcontainer.cpp
     tools/metadata/timeadjustsettings.cpp
     tools/metadata/clockphotodialog.cpp
+    tools/metadata/detbyclockphotobutton.cpp
     tools/transform/flip.cpp
     tools/transform/resize.cpp
     tools/transform/rotate.cpp

--- a/utilities/queuemanager/tools/metadata/detbyclockphotobutton.cpp
+++ b/utilities/queuemanager/tools/metadata/detbyclockphotobutton.cpp
@@ -1,0 +1,47 @@
+/*
+ *  ============================================================
+ * 
+ *  This file is a part of the digikam project
+ *  http://www.digikam.org
+ *  
+ *  Date             : 2017-01-01
+ *  Description : button for choosing time difference photo which accepts drag & drop
+ * 
+ *  Copyright (C) 2017      by Markus Leuthold <kusi at forum dot titlis dot org>
+ *  
+ *   This program is free software; you can redistribute it
+ *   and/or modify it under the terms of the GNU General
+ *   Public License as published by the Free Software Foundation;
+ *   either version 2, or (at your option) any later version.
+ *  
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *  
+ *   ============================================================
+ */
+
+// Qt includes
+#include <QtDebug> 
+#include <QMimeData>
+
+// local includes
+#include "detbyclockphotobutton.h"
+
+void DetByClockPhotoButton::dragEnterEvent(QDragEnterEvent* event)
+{
+    event->acceptProposedAction();
+}
+
+void DetByClockPhotoButton::dropEvent(QDropEvent* event)
+{
+    const QMimeData* mimeData = event->mimeData();
+
+    if (mimeData->hasUrls())
+    {
+        QUrl url = mimeData->urls().first();
+        qDebug() << "dropped clock photo: " << url;
+        emit signalClockPhotoDropped(url);
+    }
+}

--- a/utilities/queuemanager/tools/metadata/detbyclockphotobutton.h
+++ b/utilities/queuemanager/tools/metadata/detbyclockphotobutton.h
@@ -1,0 +1,53 @@
+/*
+ *  ============================================================
+ *  
+ *   This file is a part of the digikam project
+ *   http://www.digikam.org
+ *  
+ *   Date             : 2017-01-01
+ *   Description : button for choosing time difference photo which accepts drag & drop
+ *  
+ *   Copyright (C) 2017      by Markus Leuthold <kusi at forum dot titlis dot org>
+ *  
+ *   This program is free software; you can redistribute it
+ *   and/or modify it under the terms of the GNU General
+ *   Public License as published by the Free Software Foundation;
+ *   either version 2, or (at your option) any later version.
+ *  
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *  
+ * ============================================================ */ 
+
+
+#ifndef DETBYCLOCKPHOTOBUTTON_H
+#define DETBYCLOCKPHOTOBUTTON_H
+
+// Qt includes
+
+#include <QWidget>
+#include <QDragEnterEvent>
+#include <QPushButton>
+
+
+class DetByClockPhotoButton :  public QPushButton
+{
+    Q_OBJECT
+    
+public:
+    DetByClockPhotoButton(const QString &text)  : QPushButton(text)
+    {
+        setAcceptDrops(true);
+    };
+    void dragEnterEvent(QDragEnterEvent* event);
+    void dropEvent(QDropEvent* event);
+
+Q_SIGNALS:
+
+    void signalClockPhotoDropped(QUrl);    
+    
+};
+
+#endif // DETBYCLOCKPHOTOBUTTON_H

--- a/utilities/queuemanager/tools/metadata/timeadjustsettings.cpp
+++ b/utilities/queuemanager/tools/metadata/timeadjustsettings.cpp
@@ -48,6 +48,7 @@
 #include "dexpanderbox.h"
 #include "clockphotodialog.h"
 #include "dmetadata.h"
+#include "detbyclockphotobutton.h"
 
 namespace Digikam
 {
@@ -116,7 +117,7 @@ public:
 
     QSpinBox*     adjDaysInput;
 
-    QPushButton*  adjDetByClockPhotoBtn;
+    DetByClockPhotoButton*  adjDetByClockPhotoBtn;
 
     QDateEdit*    useCustDateInput;
 
@@ -216,8 +217,9 @@ TimeAdjustSettings::TimeAdjustSettings(QWidget* const parent)
     d->adjDaysLabel             = new QLabel(i18nc("time adjust offset, days value label", "days"), d->adjustSettingsBox);
     d->adjTimeInput             = new QTimeEdit(d->adjustSettingsBox);
     d->adjTimeInput->setDisplayFormat(QLatin1String("hh:mm:ss"));
-    d->adjDetByClockPhotoBtn    = new QPushButton(i18n("Determine difference from clock photo"));
-
+    d->adjDetByClockPhotoBtn    = new DetByClockPhotoButton(i18n("Determine difference from clock photo"));
+    d->adjDetByClockPhotoBtn->setToolTip(i18n("Either click or drag'n drop a photo on the button to choose a clock photo"));
+    
     adjustGBLayout->setMargin(QApplication::style()->pixelMetric(QStyle::PM_DefaultLayoutSpacing));
     adjustGBLayout->setSpacing(QApplication::style()->pixelMetric(QStyle::PM_DefaultLayoutSpacing));
     adjustGBLayout->setColumnStretch(0, 1);
@@ -287,7 +289,10 @@ TimeAdjustSettings::TimeAdjustSettings(QWidget* const parent)
             this, SLOT(slotResetDateToCurrent()));
 
     connect(d->adjDetByClockPhotoBtn, SIGNAL(clicked()),
-            this, SLOT(slotDetAdjustmentByClockPhoto()));
+            this, SLOT(slotDetAdjustmentByClockPhotoDialog()));
+
+    connect(d->adjDetByClockPhotoBtn, SIGNAL(signalClockPhotoDropped(QUrl)),
+            this, SLOT(slotDetAdjustmentByClockPhotoUrl(QUrl)));
 
     connect(d->useCustDateInput, SIGNAL(dateChanged(QDate)),
             this, SIGNAL(signalSettingsChanged()));
@@ -389,6 +394,42 @@ TimeAdjustContainer TimeAdjustSettings::settings() const
     return settings;
 }
 
+void TimeAdjustSettings::detAdjustmentByClockPhotoUrl(QUrl url)
+{
+    /* When user press the clock photo button, a dialog is displayed and set the
+    *  results to the proper widgets.
+    */
+    QPointer<ClockPhotoDialog> dlg = new ClockPhotoDialog(this, url);
+    const int result               = dlg->exec();
+
+    if (result == QDialog::Accepted)
+    {
+        DeltaTime dvalues = dlg->deltaValues();
+
+        if (dvalues.isNull())
+        {
+            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::COPYVALUE);
+        }
+        else if (dvalues.deltaNegative)
+        {
+            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::SUBVALUE);
+        }
+        else
+        {
+            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::ADDVALUE);
+        }
+
+        d->adjDaysInput->setValue(dvalues.deltaDays);
+        QTime deltaTime;
+        deltaTime.setHMS(dvalues.deltaHours, dvalues.deltaMinutes, dvalues.deltaSeconds);
+        d->adjTimeInput->setTime(deltaTime);
+
+        emit signalSettingsChanged();
+    }
+
+    delete dlg;
+}
+
 void TimeAdjustSettings::slotSrcTimestampChanged()
 {
     d->useFileDateTypeChooser->setEnabled(false);
@@ -435,43 +476,19 @@ void TimeAdjustSettings::slotAdjustmentTypeChanged()
     emit signalSettingsChanged();
 }
 
-void TimeAdjustSettings::slotDetAdjustmentByClockPhoto()
+void TimeAdjustSettings::slotDetAdjustmentByClockPhotoUrl(QUrl url)
+{
+    //usually called when a photo is dropped onto the push button
+    detAdjustmentByClockPhotoUrl(url);
+}
+
+void TimeAdjustSettings::slotDetAdjustmentByClockPhotoDialog()
 {
     // Determine the currently selected item and preselect it as clock photo
-    QUrl defaultUrl;
+    QUrl emptyUrl;
 
-    /* When user press the clock photo button, a dialog is displayed and set the
-     * results to the proper widgets.
-     */
-    QPointer<ClockPhotoDialog> dlg = new ClockPhotoDialog(this, defaultUrl);
-    const int result               = dlg->exec();
-
-    if (result == QDialog::Accepted)
-    {
-        DeltaTime dvalues = dlg->deltaValues();
-
-        if (dvalues.isNull())
-        {
-            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::COPYVALUE);
-        }
-        else if (dvalues.deltaNegative)
-        {
-            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::SUBVALUE);
-        }
-        else
-        {
-            d->adjTypeChooser->setCurrentIndex(TimeAdjustContainer::ADDVALUE);
-        }
-
-        d->adjDaysInput->setValue(dvalues.deltaDays);
-        QTime deltaTime;
-        deltaTime.setHMS(dvalues.deltaHours, dvalues.deltaMinutes, dvalues.deltaSeconds);
-        d->adjTimeInput->setTime(deltaTime);
-
-        emit signalSettingsChanged();
-    }
-
-    delete dlg;
+   detAdjustmentByClockPhotoUrl(emptyUrl);
 }
+
 
 }  // namespace Digikam

--- a/utilities/queuemanager/tools/metadata/timeadjustsettings.h
+++ b/utilities/queuemanager/tools/metadata/timeadjustsettings.h
@@ -49,6 +49,7 @@ public:
 
     void setSettings(const TimeAdjustContainer& settings);
     TimeAdjustContainer settings() const;
+    void detAdjustmentByClockPhotoUrl(QUrl url);
 
 Q_SIGNALS:
 
@@ -59,7 +60,8 @@ private Q_SLOTS:
     void slotSrcTimestampChanged();
     void slotResetDateToCurrent();
     void slotAdjustmentTypeChanged();
-    void slotDetAdjustmentByClockPhoto();
+    void slotDetAdjustmentByClockPhotoDialog();
+    void slotDetAdjustmentByClockPhotoUrl(QUrl url);
 
 private:
 


### PR DESCRIPTION
Allow to drag'n drop from either BM, digikam main window or from outside digikam to choose a
clock photo in the time adjust tool

BUGS: 296580
FIXED-IN: 5.4.0