### PR TITLE
optionally keep image extension in XMP sidecar file names

### DIFF
--- a/libs/dmetadata/metadatasettingscontainer.cpp
+++ b/libs/dmetadata/metadatasettingscontainer.cpp
@@ -53,6 +53,7 @@ MetadataSettingsContainer::MetadataSettingsContainer()
     writeRawFiles         = false;
     useXMPSidecar4Reading = false;
     metadataWritingMode   = MetaEngine::WRITETOIMAGEONLY;
+    keepExtensionInXMPSidecarName = true;
     updateFileTimeStamp   = true;
     rescanImageIfModified = false;
     rotationBehavior      = RotatingFlags | RotateByLosslessRotation;
@@ -77,6 +78,7 @@ void MetadataSettingsContainer::readFromConfig(KConfigGroup& group)
 
     //writeRawFiles         = group.readEntry("Write RAW Files",             false);
     useXMPSidecar4Reading = group.readEntry("Use XMP Sidecar For Reading", false);
+    keepExtensionInXMPSidecarName = group.readEntry("Keep Image Extension in XMP Sidecar Name", false);
     metadataWritingMode   = (MetaEngine::MetadataWritingMode)
                             group.readEntry("Metadata Writing Mode",       (int)MetaEngine::WRITETOIMAGEONLY);
     updateFileTimeStamp   = group.readEntry("Update File Timestamp",       true);
@@ -125,6 +127,7 @@ void MetadataSettingsContainer::writeToConfig(KConfigGroup& group) const
 
     group.writeEntry("Write RAW Files",             writeRawFiles);
     group.writeEntry("Use XMP Sidecar For Reading", useXMPSidecar4Reading);
+    group.writeEntry("Keep Image Extension in XMP Sidecar Name", keepExtensionInXMPSidecarName);
     group.writeEntry("Metadata Writing Mode",       (int)metadataWritingMode);
     group.writeEntry("Update File Timestamp",       updateFileTimeStamp);
     group.writeEntry("Rescan File If Modified",     rescanImageIfModified);

--- a/libs/dmetadata/metadatasettingscontainer.h
+++ b/libs/dmetadata/metadatasettingscontainer.h
@@ -100,6 +100,7 @@ public:
     bool                            updateFileTimeStamp;
     bool                            rescanImageIfModified;
     bool                            useXMPSidecar4Reading;
+    bool                            keepExtensionInXMPSidecarName;
     bool                            useLazySync;
 
     MetaEngine::MetadataWritingMode metadataWritingMode;

--- a/libs/dmetadata/metaengine.cpp
+++ b/libs/dmetadata/metaengine.cpp
@@ -30,10 +30,13 @@
 
 #include "metaengine.h"
 #include "metaengine_p.h"
+#include <QDir>
 
 // Local includes
 
 #include "digikam_debug.h"
+#include "metadatasettings.h"
+#include "metadatasettingscontainer.h"
 
 namespace Digikam
 {
@@ -164,7 +167,17 @@ QString MetaEngine::sidecarFilePathForFile(const QString& path)
 
     if (!path.isEmpty())
     {
-        ret = path + QString::fromLatin1(".xmp");
+        if (nullptr == MetadataSettings::instance() ||  // Default to this alternative, if, for some reason, we don't have settings.
+            MetadataSettings::instance()->settings().keepExtensionInXMPSidecarName)
+        {
+            ret = path + QString::fromLatin1(".xmp");
+        }
+        else
+        {
+            // Replace the image file name extension with 'xmp'.
+            QFileInfo file_info = QFileInfo(path);
+            ret = file_info.dir().filePath(file_info.completeBaseName() + QString::fromLatin1(".xmp"));
+        }
     }
 
     return ret;

--- a/utilities/setup/metadata/setupmetadata.cpp
+++ b/utilities/setup/metadata/setupmetadata.cpp
@@ -90,6 +90,7 @@ public:
         updateFileTimeStampBox(0),
         rescanImageIfModifiedBox(0),
         writingModeCombo(0),
+        keepExtensionInXMPSidecarNameBox(0),
         rotateByFlag(0),
         rotateByContents(0),
         allowRotateByMetadata(0),
@@ -130,6 +131,7 @@ public:
     QCheckBox*           updateFileTimeStampBox;
     QCheckBox*           rescanImageIfModifiedBox;
     QComboBox*           writingModeCombo;
+    QCheckBox*           keepExtensionInXMPSidecarNameBox;
 
     QRadioButton*        rotateByFlag;
     QRadioButton*        rotateByContents;
@@ -548,6 +550,12 @@ SetupMetadata::SetupMetadata(QWidget* const parent)
     d->writingModeCombo->setToolTip(i18nc("@info:tooltip", "Specify the exact mode of XMP sidecar writing"));
     d->writingModeCombo->setEnabled(false);
 
+    d->keepExtensionInXMPSidecarNameBox  = new QCheckBox;
+    d->keepExtensionInXMPSidecarNameBox->setText(i18nc("@option:check", "Keep Image Extension in XMP Sidecar Name"));
+    d->keepExtensionInXMPSidecarNameBox->setWhatsThis(i18nc("@info:whatsthis",
+                                             "If checked, when constructing the XMP sidecar file name, append '.xmp' to the image filename. Otherwise, the extension is replaced."));
+    d->keepExtensionInXMPSidecarNameBox->setEnabled(MetaEngine::supportXmp());
+
     connect(d->writeXMPSidecarBox, SIGNAL(toggled(bool)),
             d->writingModeCombo, SLOT(setEnabled(bool)));
 
@@ -555,6 +563,7 @@ SetupMetadata::SetupMetadata(QWidget* const parent)
     rwSidecarsLayout->addWidget(d->readXMPSidecarBox,  1, 0, 1, 3);
     rwSidecarsLayout->addWidget(d->writeXMPSidecarBox, 2, 0, 1, 3);
     rwSidecarsLayout->addWidget(d->writingModeCombo,   3, 1, 1, 2);
+    rwSidecarsLayout->addWidget(d->keepExtensionInXMPSidecarNameBox, 4, 0, 1, 3);
     rwSidecarsLayout->setColumnStretch(3, 10);
     rwSidecarsGroup->setLayout(rwSidecarsLayout);
 
@@ -674,6 +683,7 @@ void SetupMetadata::applySettings()
     set.useLazySync           = d->useLazySync->isChecked();
     set.writeRawFiles         = d->writeRawFilesBox->isChecked();
     set.useXMPSidecar4Reading = d->readXMPSidecarBox->isChecked();
+    set.keepExtensionInXMPSidecarName = d->keepExtensionInXMPSidecarNameBox->isChecked();
 
     if (d->writeXMPSidecarBox->isChecked())
     {
@@ -755,6 +765,7 @@ void SetupMetadata::readSettings()
     d->useLazySync->setChecked(set.useLazySync);
     d->writeRawFilesBox->setChecked(set.writeRawFiles);
     d->readXMPSidecarBox->setChecked(set.useXMPSidecar4Reading);
+    d->keepExtensionInXMPSidecarNameBox->setChecked(set.keepExtensionInXMPSidecarName);
     d->updateFileTimeStampBox->setChecked(set.updateFileTimeStamp);
     d->rescanImageIfModifiedBox->setChecked(set.rescanImageIfModified);
 


### PR DESCRIPTION
Many programs (Capture One Pro, Lightroom (I believe), and others) construct the XMP sidecar file name _without_ the image file name extension, replacing it with 'xmp'. digiKam (and several others, like darktable) instead append '.xmp' to the full image file name, including the original extension.

There are pros and cons to both approaches.

The changes in this commit make it configurable to keep the image extension or not in the file name when constructing an XMP sidecar file name.
A checkbox (defaults to checked) "Keep Image Extension in XMP Sidecar Name" was added to Settings > Configure digiKam > Metadata > Sidecars.

Some references:
https://bugs.kde.org/show_bug.cgi?id=264007
https://photo.stackexchange.com/questions/86830/digikam-metadata-in-xmp-sidecarfiles-using-myphoto-xmp-instead-of-myphoto-jpg-xm
https://mail.kde.org/pipermail/digikam-users/2012-June/016381.html
https://mail.kde.org/pipermail/digikam-devel/2013-January/065996.html
https://discuss.pixls.us/t/linux-applications-and-their-non-standard-xmp-sidecar-naming-convention/2688

Note:
Because the member functions involved in MetaEngine are static, I access the setting using the MetadataSettings singleton. This is not the current behaviour in MetaEngine with other settings, but I think this is a good way to accomplish the goal. An alternative would be to make the functions non-static, but my guess is that it would involve quite a bit of refactoring. (And I'm not sure why the settings are currently being copied into MetaEngine, when they could just be accessed using the MetadataSettings singleton...)