### PR TITLE
language/typo fixes

### DIFF
--- a/project/bundles/macports/installer/releasenotes.html
+++ b/project/bundles/macports/installer/releasenotes.html
@@ -20,32 +20,32 @@
 
 We would like to inform you that port of digiKam under MacOS is not as stable as the Linux version.
 
-digiKam must works mostly fine under MacOS, but some features are still missing due to not yet 
+digiKam works mostly fine under MacOS, but some features are still missing due to not yet 
 implemented features in the underlying <a href="http://www.kde.org">KDE.org</a> libraries, even if since 
 digiKam 5.0.0 release, the dependencies to this framework have been seriously reduced. 
 
-This installer have be compiled using <a href="https://www.macports.org/">Macports project</a>.
+This installer has been compiled using the <a href="https://www.macports.org/">Macports project</a>.
 
-<h1>License</h1>
+<h1>Licence</h1>
 
 digiKam is an open-source project published under the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0">General Public Licence</a> version 2 or later.
 
 <h1>Internationalization</h1>
 
-This installer include a lots of application translations. To change current language,
-go to Help menu and use Switch Application Language option. digiKam need to be restarted to take effect.
+This installer includes a lot of application translations. To change current language,
+go to the Help menu and use the Switch Application Language option. digiKam needs to be restarted for this to take effect.
 
 <h1>Documentation</h1>
 
-To limit size of this bundle, the large digiKam documentation is not include inside. The complete handbook is available online 
+To limit the size of this bundle, the large digiKam documentation is not included. The complete handbook is available online 
 <a href="https://docs.kde.org/trunk5/en/extragear-graphics/digikam/index.html">as HTML</a> or 
 <a href="https://docs.kde.org/trunk5/en/extragear-graphics/digikam/digikam.pdf">as PDF</a>.
 
 <h1>Requirements and Limitations</h1>
 
-Internal database server require to install localy a database backend for MacOS, as <a href="https://www.mysql.com/downloads/">Mysql</a> or <a href="https://downloads.mariadb.org/">MariaDB</a>.
+Internal database server required to install locally a database backend for MacOS, as <a href="https://www.mysql.com/downloads/">Mysql</a> or <a href="https://downloads.mariadb.org/">MariaDB</a>.
 
-Camera auto detection do not work yet as under Linux due to limitations in <a href="https://solid.kde.org">Solid hardware interface</a> used by digiKam.
+Camera auto detection does not work yet as under Linux due to limitations in <a href="https://solid.kde.org">Solid hardware interface</a> used by digiKam.
 
 Panorama and ExpoBlending tools require to install <a href="http://hugin.sourceforge.net/">Hugin runtime components</a> to process files.
 


### PR DESCRIPTION
Language/typo fixes; document used both "Licence" and "License" as a noun, unified to "Licence".

Well, duh. Just now spotted the note below.
If this seems useful enough, please feel free to use the diff :)

DO NOT ISSUE PULL REQUESTS ON GITHUB

Github is only a mirror. Our real development happens on
the KDE infrastructure. Post diffs and review requests
against Krita here:

https://phabricator.kde.org
